### PR TITLE
Pulls redis and postgres into separate files

### DIFF
--- a/params/hybox.json
+++ b/params/hybox.json
@@ -1,11 +1,11 @@
 [
   {
     "ParameterKey": "KeyName",
-    "ParameterValue": "zookeeper"
+    "ParameterValue": "hybox"
   },
   {
     "ParameterKey": "HostedZoneName",
-    "ParameterValue": "vpc.hydrainabox.org."
+    "ParameterValue": "hydrainabox.org."
   },
   {
     "ParameterKey": "SecretKeyBase",
@@ -22,5 +22,21 @@
   {
     "ParameterKey": "ZookeeperHosts",
     "ParameterValue": "zk.vpc.hydrainabox.org:2181"
+  },
+  {
+    "ParameterKey": "RedisHost",
+    "ParameterValue": "red-re-donyvytt1t4y.z8eryy.0001.use1.cache.amazonaws.com"
+  },
+  {
+    "ParameterKey": "RDSUsername",
+    "ParameterValue": "ebroot"
+  },
+  {
+    "ParameterKey": "RDSPassword",
+    "ParameterValue": "adminadmin"
+  },
+  {
+    "ParameterKey": "RDSHostname",
+    "ParameterValue": "pd1xy7tdyq5zmc7.ctq01obrgcgr.us-east-1.rds.amazonaws.com"
   }
 ]

--- a/params/postgres.json
+++ b/params/postgres.json
@@ -1,0 +1,6 @@
+[
+  {
+    "ParameterKey": "MasterUserPassword",
+    "ParameterValue": "changeme"
+  }
+]

--- a/stacks/hybox.json
+++ b/stacks/hybox.json
@@ -9,7 +9,7 @@
     "S3Bucket": {
       "Type": "String",
       "Description": "S3 bucket with the hybox zip",
-      "Default": "hybox-deployment-artifacts" 
+      "Default": "hybox-deployment-artifacts"
     },
     "S3Key": {
       "Type": "String",
@@ -39,8 +39,8 @@
       "Description" : "Secret key for Rails",
       "Type" : "String"
     },
-    "FcrepoUrl" : {
-      "Description" : "URL to Fcrepo",
+    "FedoraUrl" : {
+      "Description" : "URL to Fedora",
       "Type" : "String"
     },
     "SolrUrl" : {
@@ -51,6 +51,39 @@
       "Type": "String",
       "Description": "A list of zookeeper host IP + ports",
       "Default": "127.0.0.1:2181"
+    },
+    "RedisHost": {
+      "Type": "String",
+      "Description": "URL to Redis"
+    },
+    "RedisPort": {
+      "Type": "String",
+      "Description": "Redis Port",
+      "Default": "6379"
+    },
+    "RDSDatabaseName": {
+      "Type": "String",
+      "Description": "Database name",
+      "Default": "hybox"
+    },
+    "RDSUsername": {
+      "Type": "String",
+      "Description": "Username for Database",
+      "Default": "root"
+    },
+    "RDSPassword": {
+      "Type": "String",
+      "Description": "Password for Database",
+      "Default": "changeme"
+    },
+    "RDSHostname": {
+      "Type": "String",
+      "Description": "Hostname for RDS Database"
+    },
+    "RDSPort": {
+      "Type": "String",
+      "Description": "Database Port",
+      "Default": "5432"
     }
   },
   "Resources" : {
@@ -80,6 +113,11 @@
         "OptionSettings" : [
           {
             "Namespace" : "aws:autoscaling:launchconfiguration",
+            "OptionName" : "ImageId",
+            "Value" : "ami-f329cd9e"
+          },
+          {
+            "Namespace" : "aws:autoscaling:launchconfiguration",
             "OptionName" : "InstanceType",
             "Value" : "t2.large"
           },
@@ -96,7 +134,7 @@
           {
             "Namespace" : "aws:autoscaling:launchconfiguration",
             "OptionName" : "IamInstanceProfile",
-            "Value" : { "Ref" : "EC2InstanceProfile" }
+            "Value" : {"Fn::GetAtt" : ["EC2InstanceProfile", "Arn"] }
           },
           {
             "Namespace": "aws:autoscaling:asg",
@@ -114,7 +152,7 @@
             "Value": "SingleInstance"
           }
         ],
-        "SolutionStackName" : "64bit Amazon Linux 2016.03 v2.1.0 running Tomcat 8 Java 8"
+        "SolutionStackName" : "64bit Amazon Linux 2016.03 v2.1.0 running Ruby 2.3 (Puma)"
       }
     },
     "HyboxEnvironment": {
@@ -122,6 +160,7 @@
       "Properties": {
         "ApplicationName": { "Ref": "HyboxApplication" },
         "Description": "Hybox Environment",
+        "EnvironmentName": "HyBoxEBEnvironment",
         "TemplateName": { "Ref": "HyboxConfigurationTemplate" },
         "VersionLabel": { "Ref": "HyboxApplicationVersion" },
         "OptionSettings" : [
@@ -143,17 +182,42 @@
           {
             "Namespace": "aws:elasticbeanstalk:application:environment",
             "OptionName": "REDIS_HOST",
-            "Value": { "Fn::GetAtt" : ["RedisCluster", "RedisEndpoint.Address"] }
+            "Value": { "Ref" : "RedisHost"}
           },
           {
             "Namespace": "aws:elasticbeanstalk:application:environment",
             "OptionName": "REDIS_PORT",
-            "Value": { "Fn::GetAtt" : ["RedisCluster", "RedisEndpoint.Port"] }
+            "Value": { "Ref" : "RedisPort"}
           },
           {
             "Namespace": "aws:elasticbeanstalk:application:environment",
             "OptionName": "Settings.zookeeper.connection_str",
             "Value": { "Ref" : "ZookeeperHosts"}
+          },
+          {
+            "Namespace": "aws:elasticbeanstalk:application:environment",
+            "OptionName": "RDS_DB_NAME",
+            "Value": { "Ref" : "RDSDatabaseName"}
+          },
+          {
+            "Namespace": "aws:elasticbeanstalk:application:environment",
+            "OptionName": "RDS_USERNAME",
+            "Value": { "Ref" : "RDSUsername"}
+          },
+          {
+            "Namespace": "aws:elasticbeanstalk:application:environment",
+            "OptionName": "RDS_PASSWORD",
+            "Value": { "Ref" : "RDSPassword"}
+          },
+          {
+            "Namespace": "aws:elasticbeanstalk:application:environment",
+            "OptionName": "RDS_HOSTNAME",
+            "Value": { "Ref" : "RDSHostname"}
+          },
+          {
+            "Namespace": "aws:elasticbeanstalk:application:environment",
+            "OptionName": "RDS_PORT",
+            "Value": { "Ref" : "RDSPort"}
           }
         ]
       }
@@ -220,36 +284,6 @@
         "TTL": "900",
         "ResourceRecords" : [{ "Fn::GetAtt" : ["HyboxEnvironment", "EndpointURL"] }]
       }
-    },
-    "RedisCluster": {
-      "Type": "AWS::ElastiCache::CacheCluster",
-      "Properties": {
-        "CacheNodeType": {
-          "Ref": "ClusterNodeType"
-        },
-        "CacheSecurityGroupNames": [
-          {
-            "Ref": "RedisClusterSecurityGroup"
-          }
-        ],
-        "Engine": "redis",
-        "NumCacheNodes": "1"
-      }
-    },
-    "RedisClusterSecurityGroup": {
-      "Type": "AWS::ElastiCache::SecurityGroup",
-      "Properties": {
-        "Description": "Lock the cluster down"
-      }
-    },
-    "RedisClusterSecurityGroupIngress": {
-      "Type": "AWS::ElastiCache::SecurityGroupIngress",
-      "Properties": {
-        "CacheSecurityGroupName": {
-          "Ref": "RedisClusterSecurityGroup"
-        },
-        "EC2SecurityGroupName": "default"
-      }
     }
   },
   "Outputs": {
@@ -260,8 +294,7 @@
           "",
           [
             "http://",
-            { "Ref" : "EBRecordSet" },
-            "/rest/"
+            { "Ref" : "EBRecordSet" }
           ]
         ]
       }

--- a/stacks/postgres.json
+++ b/stacks/postgres.json
@@ -1,0 +1,69 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Parameters" : {
+    "DatabaseName": {
+      "Type": "String",
+      "Description": "Name of the database",
+      "Default": "hybox"
+    },
+    "MasterUsername": {
+      "Type": "String",
+      "Description": "Database Root Username",
+      "Default": "root"
+    },
+    "DBInstanceClass": {
+      "Type": "String",
+      "Default" : "db.t2.medium",
+      "Description": "Instance size"
+    },
+    "MasterUserPassword": {
+      "Type": "String",
+      "Description": "Password for the DB Root User"
+    },
+    "EC2SecurityGroup": {
+      "Type": "List<AWS::EC2::SecurityGroup::GroupName>",
+      "Description": "A list of security group names, such as my-sg-ab.",
+      "Default": "default"
+    },
+    "AllocatedStorage" : {
+      "Description" : "Size of DB in Gigs",
+      "Type" : "String",
+      "Default": "5"
+    }
+  },
+  "Resources": {
+    "DBInstance" : {
+      "Type": "AWS::RDS::DBInstance",
+      "Properties": {
+        "DBName": { "Ref" : "DatabaseName" },
+        "Engine": "postgres",
+        "MasterUsername": { "Ref" : "MasterUsername" },
+        "DBInstanceClass": { "Ref" : "DBInstanceClass" },
+        "DBSecurityGroups": [ { "Ref" : "DBSecurityGroup" } ],
+        "AllocatedStorage": { "Ref" : "AllocatedStorage" },
+        "MasterUserPassword": { "Ref" : "DBInstanceClass" }
+      }
+    },
+    "DBSecurityGroup": {
+      "Type": "AWS::RDS::DBSecurityGroup",
+      "Properties": {
+        "DBSecurityGroupIngress": { "EC2SecurityGroupName": { "Fn::Join": ["", { "Ref" : "SecurityGroups" }] } },
+        "GroupDescription"      : "Frontend Access"
+      }
+    }
+  },
+  "Outputs": {
+    "EndpointAddress": {
+      "Description": "Postgres endpoint address",
+      "Value": {
+        "Fn::GetAtt": [ "DBInstance", "Endpoint.Address" ]
+      }
+    },
+    "EndpointPort": {
+      "Description": "Postgres endpoint port",
+      "Value": {
+        "Fn::GetAtt": [ "DBInstance", "Endpoint.Port" ]
+      }
+    }
+  }
+}

--- a/stacks/redis.json
+++ b/stacks/redis.json
@@ -1,0 +1,47 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Resources": {
+    "RedisCluster": {
+      "Type": "AWS::ElastiCache::CacheCluster",
+      "Properties": {
+        "CacheNodeType": "cache.m1.small",
+        "CacheSecurityGroupNames": [
+          {
+            "Ref": "RedisClusterSecurityGroup"
+          }
+        ],
+        "Engine": "redis",
+        "NumCacheNodes": "1"
+      }
+    },
+    "RedisClusterSecurityGroup": {
+      "Type": "AWS::ElastiCache::SecurityGroup",
+      "Properties": {
+        "Description": "Lock the cluster down"
+      }
+    },
+    "RedisClusterSecurityGroupIngress": {
+      "Type": "AWS::ElastiCache::SecurityGroupIngress",
+      "Properties": {
+        "CacheSecurityGroupName": {
+          "Ref": "RedisClusterSecurityGroup"
+        },
+        "EC2SecurityGroupName": "default"
+      }
+    }
+  },
+  "Outputs": {
+    "EndpointAddress": {
+      "Description": "The Redis endpoint address",
+      "Value": {
+        "Fn::GetAtt": [ "RedisCluster", "RedisEndpoint.Address" ]
+      }
+    },
+    "EndpointPort": {
+      "Description": "The Redis endpoint port",
+      "Value": {
+        "Fn::GetAtt": [ "RedisCluster", "RedisEndpoint.Port" ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
This works to make postgres and redis instances however the EB instance fails to start the application due to not knowing what to do about the `Settings.zookeeper.connection_str` env variable.
