### PR TITLE
Updates ECS AMI IDs to the latest values as defined here: http://docs…

### DIFF
--- a/templates/solr.json
+++ b/templates/solr.json
@@ -74,30 +74,38 @@
   "Mappings" : {
     "AWSRegionToAMI" : {
       "us-east-1": {
-        "AMIID": "ami-6bb2d67c"
+        "AMIID": "ami-a58760b3"
+      },
+      "us-east-2": {
+        "AMIID": "ami-a6e4bec3"
       },
       "us-west-1": {
-        "AMIID": "ami-70632110"
+        "AMIID": "ami-74cb9b14"
       },
       "us-west-2": {
-        "AMIID": "ami-2d1bce4d"
+        "AMIID": "ami-5b6dde3b"
       },
       "eu-west-1": {
-        "AMIID": "ami-078df974"
+        "AMIID": "ami-e3fbd290"
       },
+      "eu-west-2": {
+        "AMIID": "ami-77f6fc13"
+      },	  
       "eu-central-1": {
-        "AMIID": "ami-d3cf3ebc"
+        "AMIID": "ami-38dc1157"
       },
       "ap-northeast-1": {
-        "AMIID": "ami-2b6ba64a"
+        "AMIID": "ami-30bdce57"
       },
       "ap-southeast-1": {
-        "AMIID": "ami-55598036"
+        "AMIID": "ami-9f75ddfc"
       },
       "ap-southeast-2": {
-        "AMIID": "ami-0e20176d"
+        "AMIID": "ami-cf393cac"
+      },
+      "ca-central-1": {
+        "AMIID": "ami-1b01b37f"
       }
-    }
   },
 
   "Resources" : {

--- a/templates/zookeeper.json
+++ b/templates/zookeeper.json
@@ -58,28 +58,37 @@
   "Mappings" : {
     "AWSRegionToAMI" : {
       "us-east-1": {
-        "AMIID": "ami-6bb2d67c"
+        "AMIID": "ami-a58760b3"
+      },
+      "us-east-2": {
+        "AMIID": "ami-a6e4bec3"
       },
       "us-west-1": {
-        "AMIID": "ami-70632110"
+        "AMIID": "ami-74cb9b14"
       },
       "us-west-2": {
-        "AMIID": "ami-2d1bce4d"
+        "AMIID": "ami-5b6dde3b"
       },
       "eu-west-1": {
-        "AMIID": "ami-078df974"
+        "AMIID": "ami-e3fbd290"
       },
+      "eu-west-2": {
+        "AMIID": "ami-77f6fc13"
+      },	  
       "eu-central-1": {
-        "AMIID": "ami-d3cf3ebc"
+        "AMIID": "ami-38dc1157"
       },
       "ap-northeast-1": {
-        "AMIID": "ami-2b6ba64a"
+        "AMIID": "ami-30bdce57"
       },
       "ap-southeast-1": {
-        "AMIID": "ami-55598036"
+        "AMIID": "ami-9f75ddfc"
       },
       "ap-southeast-2": {
-        "AMIID": "ami-0e20176d"
+        "AMIID": "ami-cf393cac"
+      },
+      "ca-central-1": {
+        "AMIID": "ami-1b01b37f"
       }
     }
   },


### PR DESCRIPTION
….aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html.

Update is due to this notice from AWS: Docker has released Docker Engine version 1.12.6 to address the vulnerability in RunC (CVE-2016-9962). According to our records you are currently running or you have recently launched an Amazon ECS-optimized AMI that uses an old version of Docker. To address CVE 2016-9962 (https://alas.aws.amazon.com/ALAS-2017-783.html ), we recommend that you update to the latest Amazon ECS-optimized AMI.