### PR TITLE
Add rake task to check solution stacks against current Elastic Beanstalk list

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source 'https://rubygems.org'
 
 gem 'rake'
 gem 'jsonlint'
+
+group :development do
+  gem 'aws-sdk'
+  gem 'fuzzy_match'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -34,6 +34,7 @@ task :audit_solution_stacks do
   stacks = Aws::ElasticBeanstalk::Client.new.list_available_solution_stacks.solution_stacks
   matcher = FuzzyMatch.new(stacks)
   files = Dir['templates/*.json']
+  exit_code = 0
 
   files.each do |file|
     doc = JSON.parse(File.read(file))
@@ -42,12 +43,14 @@ task :audit_solution_stacks do
     solution_stack = template['Properties']['SolutionStackName']
     next if solution_stack.nil?
     if stacks.include?(solution_stack)
-      puts "#{file}: Solution Stack `#{solution_stack}': OK"
+      $stderr.puts "#{file}: Solution Stack `#{solution_stack}': OK"
     else
-      puts "#{file}: Solution Stack `#{solution_stack}': NOT FOUND"
-      puts "  Did you mean `#{matcher.find(solution_stack)}'?"
+      $stderr.puts "#{file}: Solution Stack `#{solution_stack}': NOT FOUND"
+      $stderr.puts "  Did you mean `#{matcher.find(solution_stack)}'?"
+      exit_code = 1
     end
   end
+  exit exit_code
 end
 
 task default: [:jsonlint, :copy_artifacts]


### PR DESCRIPTION
Checks Elastic Beanstalk solution stacks specified in local configuration templates against the latest list pulled directly from AWS. Warns of mismatches and uses fuzzy matching to suggest fixes.

```
$ rake audit_solution_stacks
templates/fcrepo.json: Solution Stack `64bit Amazon Linux 2016.09 v2.5.3 running Tomcat 8 Java 8': OK
templates/webapp.json: Solution Stack `64bit Amazon Linux 2016.09 v2.3.1 running Ruby 2.3 (Puma)': NOT FOUND
  Did you mean `64bit Amazon Linux 2016.09 v2.3.2 running Ruby 2.3 (Puma)'?
templates/worker.json: Solution Stack `64bit Amazon Linux 2016.09 v2.3.2 running Ruby 2.3 (Puma)': OK
```