### PR TITLE
Use RDS Postgres for the Fedora database

### DIFF
--- a/params/defaults.json
+++ b/params/defaults.json
@@ -44,6 +44,26 @@
     "ParameterValue": "true"
   },
   {
+    "ParameterKey": "FcrepoDatabaseUsername",
+    "ParameterValue": "ebroot"
+  },
+  {
+    "ParameterKey": "FcrepoDatabasePassword",
+    "ParameterValue": ""
+  },
+  {
+    "ParameterKey": "FcrepoDatabaseName",
+    "ParameterValue": "fcrepo"
+  },
+  {
+    "ParameterKey": "FcrepoDatabaseStorageSize",
+    "ParameterValue": "5"
+  },
+  {
+    "ParameterKey": "FcrepoDatabaseMultiAZ",
+    "ParameterValue": "true"
+  },
+  {
     "ParameterKey": "SecretKeyBase",
     "ParameterValue": ""
   },
@@ -141,6 +161,10 @@
   },
   {
     "ParameterKey": "DatabaseInstanceType",
+    "ParameterValue": "db.t2.medium"
+  },
+  {
+    "ParameterKey": "FcrepoDatabaseInstanceType",
     "ParameterValue": "db.t2.medium"
   },
   {

--- a/templates/fcrepo.json
+++ b/templates/fcrepo.json
@@ -46,6 +46,27 @@
     "InstanceType" : {
       "Type" : "String",
       "Description" : "The EC2 instance type"
+    },
+    "RDSDatabaseName": {
+      "Type": "String",
+      "Description": "Database name"
+    },
+    "RDSUsername": {
+      "Type": "String",
+      "Description": "Username for Database"
+    },
+    "RDSPassword": {
+      "Type": "String",
+      "Description": "Password for Database",
+      "NoEcho": "true"
+    },
+    "RDSHostname": {
+      "Type": "String",
+      "Description": "Hostname for RDS Database"
+    },
+    "RDSPort": {
+      "Type": "String",
+      "Description": "Database Port"
     }
   },
   "Resources" : {
@@ -166,12 +187,19 @@
           {
             "Namespace": "aws:elasticbeanstalk:container:tomcat:jvmoptions",
             "OptionName": "JVM Options",
-            "Value": "-Dfcrepo.modeshape.configuration=\"classpath:/config/file-simple/repository.json\""
+            "Value": { "Fn::Join": ["", [
+                "-Duser.dir=\"/var/lib/fcrepo\"",
+                " -Dfcrepo.postgresql.host=\"", { "Ref" : "RDSHostname" }, "\"",
+                " -Dfcrepo.postgresql.port=\"", { "Ref" : "RDSPort" }, "\"",
+                " -Dfcrepo.postgresql.username=\"", { "Ref" : "RDSUsername" }, "\"",
+                " -Dfcrepo.postgresql.password=\"", { "Ref" : "RDSPassword" }, "\"",
+                " -Dfcrepo.modeshape.configuration=\"classpath:/config/jdbc-postgresql/repository.json\""
+              ]]}
           },
           {
             "Namespace": "aws:elasticbeanstalk:application",
             "OptionName": "Application Healthcheck URL",
-            "Value": "/"
+            "Value": "/rest"
           },
           {
             "Namespace": "aws:elb:listener:80",

--- a/templates/securitygroups.json
+++ b/templates/securitygroups.json
@@ -70,6 +70,22 @@
          "Tags" : [ { "Key" : "Name", "Value" : { "Fn::Join" : ["-", [{ "Ref" : "StackName" }, "db"] ] } } ]
       }
     },
+    "FcrepoDatabaseSecurityGroup" : {
+      "Type" : "AWS::EC2::SecurityGroup",
+      "Properties" : {
+         "GroupDescription" : "Fedora RDS security group",
+         "VpcId" : { "Ref" : "VPC" },
+         "SecurityGroupIngress" : [
+           {
+             "SourceSecurityGroupId" : { "Ref" : "FedoraSecurityGroup" },
+             "IpProtocol": "tcp",
+             "FromPort" : "5432",
+             "ToPort" : "5432"
+           }
+         ],
+         "Tags" : [ { "Key" : "Name", "Value" : { "Fn::Join" : ["-", [{ "Ref" : "StackName" }, "fcrepodb"] ] } } ]
+      }
+    },
     "RedisSecurityGroup" : {
       "Type" : "AWS::EC2::SecurityGroup",
       "Properties" : {
@@ -265,6 +281,10 @@
     "Database" : {
       "Description": "Security Group ID for the database security group",
       "Value": { "Ref" : "DatabaseSecurityGroup" }
+    },
+    "FcrepoDatabase" : {
+      "Description": "Security Group ID for the database security group",
+      "Value": { "Ref" : "FcrepoDatabaseSecurityGroup" }
     },
     "Redis" : {
       "Description": "Security Group ID for the redis security group",

--- a/templates/stack.json
+++ b/templates/stack.json
@@ -48,6 +48,27 @@
       "Type" : "String",
       "Description" : "Launch the database in multiple availability zones"
     },
+    "FcrepoDatabaseUsername": {
+      "Type": "String",
+      "Description": "Database Root Username"
+    },
+    "FcrepoDatabasePassword": {
+      "Type": "String",
+      "Description": "Password for the DB Root User",
+      "NoEcho": "true"
+    },
+    "FcrepoDatabaseName": {
+      "Type": "String",
+      "Description": "Name of the database"
+    },
+    "FcrepoDatabaseStorageSize" : {
+      "Type" : "String",
+      "Description" : "Size of DB in Gigs"
+    },
+    "FcrepoDatabaseMultiAZ" : {
+      "Type" : "String",
+      "Description" : "Launch the database in multiple availability zones"
+    },
     "SecretKeyBase" : {
       "Type" : "String",
       "Description" : "Secret key for Rails",
@@ -151,6 +172,10 @@
       "Type": "String",
       "Description": "Instance type to launch"
     },
+    "FcrepoDatabaseInstanceType" : {
+      "Type": "String",
+      "Description": "Instance type to launch"
+    },
     "SlackWebhookToken": {
       "Type": "String",
       "Description": "Slack generated token for Incoming Webhook",
@@ -198,7 +223,11 @@
         },
         {
           "Label" : { "default" : "Resources"},
-          "Parameters" : ["WorkerInstanceType", "WorkerMinSize", "WorkerMaxSize", "WebappInstanceType", "WebappMinSize", "WebappMaxSize", "DatabaseInstanceType", "RedisInstanceType", "FcrepoInstanceType", "SolrCloudSize", "SolrCloudInstanceType", "ZookeeperEnsembleSize", "ZookeeperEnsembleInstanceType"]
+          "Parameters" : ["WorkerInstanceType", "WorkerMinSize", "WorkerMaxSize", "WebappInstanceType", "WebappMinSize", "WebappMaxSize", "DatabaseInstanceType", "FcrepoDatabaseInstanceType", "RedisInstanceType", "FcrepoInstanceType", "SolrCloudSize", "SolrCloudInstanceType", "ZookeeperEnsembleSize", "ZookeeperEnsembleInstanceType"]
+        },
+        {
+          "Label" : { "default" : "Fedora Repository Configuration" },
+          "Parameters" : [ "FcrepoDatabaseUsername", "FcrepoDatabasePassword" ]
         },
         {
           "Label" : { "default" : "Application Configuration" },
@@ -261,7 +290,12 @@
           "MinSize" : { "Ref" : "FcrepoMinSize" },
           "MaxSize" : { "Ref" : "FcrepoMaxSize" },
           "HostedZoneName" : { "Fn::GetAtt" : ["vpc", "Outputs.HostedZoneName"] },
-          "InstanceType" : { "Ref" : "FcrepoInstanceType" }
+          "InstanceType" : { "Ref" : "FcrepoInstanceType" },
+          "RDSDatabaseName" : { "Fn::GetAtt" : ["fcrepodb", "Outputs.DatabaseName"] },
+          "RDSHostname" : { "Fn::GetAtt" : ["fcrepodb", "Outputs.EndpointAddress"] },
+          "RDSPort" : { "Fn::GetAtt" : ["fcrepodb", "Outputs.EndpointPort"] },
+          "RDSUsername" : { "Ref" : "FcrepoDatabaseUsername" },
+          "RDSPassword" : { "Ref" : "FcrepoDatabasePassword" }
         },
         "TemplateURL" : { "Fn::Join" : ["", ["https://s3.amazonaws.com/", { "Ref" : "S3Bucket" }, "/cloudformation/", { "Ref" : "S3KeyPrefix"}, "/templates/fcrepo.json"]] }
       }
@@ -309,6 +343,22 @@
           "AllocatedStorage" : { "Ref" : "DatabaseStorageSize" },
           "MultiAZDatabase" : { "Ref" : "DatabaseMultiAZ" },
           "DBInstanceClass" : { "Ref" : "DatabaseInstanceType" }
+        },
+        "TemplateURL" : { "Fn::Join" : ["", ["https://s3.amazonaws.com/", { "Ref" : "S3Bucket" }, "/cloudformation/", { "Ref" : "S3KeyPrefix"}, "/templates/postgres.json"]] }
+      }
+    },
+    "fcrepodb" : {
+      "Type" : "AWS::CloudFormation::Stack",
+      "Properties" : {
+        "Parameters" : {
+          "SubnetID" : { "Fn::GetAtt" : ["vpc", "Outputs.PrivateSubnets"] },
+          "SecurityGroups" : { "Fn::GetAtt" : [ "securitygroups", "Outputs.FcrepoDatabase"] },
+          "MasterUsername" : { "Ref" : "FcrepoDatabaseUsername" },
+          "MasterUserPassword" : { "Ref" : "FcrepoDatabasePassword" },
+          "DatabaseName" : { "Ref" : "FcrepoDatabaseName" },
+          "AllocatedStorage" : { "Ref" : "FcrepoDatabaseStorageSize" },
+          "MultiAZDatabase" : { "Ref" : "FcrepoDatabaseMultiAZ" },
+          "DBInstanceClass" : { "Ref" : "FcrepoDatabaseInstanceType" }
         },
         "TemplateURL" : { "Fn::Join" : ["", ["https://s3.amazonaws.com/", { "Ref" : "S3Bucket" }, "/cloudformation/", { "Ref" : "S3KeyPrefix"}, "/templates/postgres.json"]] }
       }


### PR DESCRIPTION
Addresses #120 

Reuses `postgres.json` template with different params to set up a postgres database for Fedora and configures Fedora to use it. Binary storage is still file-based.