### PR TITLE
Fcrepo S3 binary storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,19 @@ $ AWS_DEFAULT_REGION=us-east-1
 
 2. Create a [public hosted zone](http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/CreatingHostedZone.html); the web application will automatically manage DNS entries in this zone.
 
-3. Copy the `params/defaults.json` template to a new environment-specific file, populating the parameter values as appropriate for your environment (and, particularly, the key name and hosted zone created above; the other settings, while insecure, may suffice for development purposes). This repo ignores a local file named `params/private.json` where secret params can be set.
+3. Create an [S3 bucket](http://docs.aws.amazon.com/AmazonS3/latest/user-guide/create-bucket.html) to be used for the persistent storage of binary content.
 
-4. Create the full application stack:
+4. Create an [IAM user](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html) and [give that user permission](https://aws.amazon.com/blogs/security/writing-iam-policies-how-to-grant-access-to-an-amazon-s3-bucket/) to access the S3 bucket created in the previous step. Make sure to capture the new user's API access credentials.
+
+5. Copy the `params/defaults.json` template to a new environment-specific file, populating the parameter values as appropriate for your environment. This repo ignores a local file named `params/private.json` where secret params can be set. Make sure to set values for at least these parameters (the default settings, while insecure, will work for the other parameters, and should suffice for development purposes):
+   - `KeyName`: the name of the key-pair created in step 1
+   - `PublicZoneName`: the name of the hosted zone created in step 2 (with a trailing period)
+   - `DatabasePassword` and `FcrepoDatabasePassword`: password for Hyku and Fedora DatabaseStorageSize
+   - `FcrepoS3BucketName`: the name of the S3 bucket created in step 3
+   - `FcrepoS3AccessKey` and `FcrepoS3SecretKey`: API credentials for user created in step 4
+   - `SecretKeyBase`: rails key generation base
+
+6. Create the full application stack:
 
 ```console
 $ aws --region $AWS_DEFAULT_REGION cloudformation create-stack --stack-name hybox --template-body https://s3.amazonaws.com/hybox-deployment-artifacts/cloudformation/current/templates/stack.json --capabilities CAPABILITY_IAM --parameters file://params/private.json

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ AWS_DEFAULT_REGION=us-east-1
 5. Copy the `params/defaults.json` template to a new environment-specific file, populating the parameter values as appropriate for your environment. This repo ignores a local file named `params/private.json` where secret params can be set. Make sure to set values for at least these parameters (the default settings, while insecure, will work for the other parameters, and should suffice for development purposes):
    - `KeyName`: the name of the key-pair created in step 1
    - `PublicZoneName`: the name of the hosted zone created in step 2 (with a trailing period)
-   - `DatabasePassword` and `FcrepoDatabasePassword`: password for Hyku and Fedora DatabaseStorageSize
+   - `DatabasePassword` and `FcrepoDatabasePassword`: password for Hyku and Fedora databases
    - `FcrepoS3BucketName`: the name of the S3 bucket created in step 3
    - `FcrepoS3AccessKey` and `FcrepoS3SecretKey`: API credentials for user created in step 4
    - `SecretKeyBase`: rails key generation base

--- a/params/defaults.json
+++ b/params/defaults.json
@@ -65,7 +65,7 @@
   },
   {
     "ParameterKey": "FcrepoHomePath",
-    "ParameterValue": "/var/lib/fcrepo"
+    "ParameterValue": "/usr/share/tomcat8/fcrepo4-data"
   },
   {
     "ParameterKey": "FcrepoS3AccessKey",

--- a/params/defaults.json
+++ b/params/defaults.json
@@ -65,7 +65,7 @@
   },
   {
     "ParameterKey": "FcrepoHomePath",
-    "ParameterValue": "/var/lib/tomcat8/fcrepo"
+    "ParameterValue": "/var/lib/fcrepo"
   },
   {
     "ParameterKey": "FcrepoS3AccessKey",

--- a/params/defaults.json
+++ b/params/defaults.json
@@ -64,6 +64,22 @@
     "ParameterValue": "true"
   },
   {
+    "ParameterKey": "FcrepoHomePath",
+    "ParameterValue": "/var/lib/tomcat8/fcrepo"
+  },
+  {
+    "ParameterKey": "FcrepoS3AccessKey",
+    "ParameterValue": ""
+  },
+  {
+    "ParameterKey": "FcrepoS3SecretKey",
+    "ParameterValue": ""
+  },
+  {
+    "ParameterKey": "FcrepoS3BucketName",
+    "ParameterValue": ""
+  },
+  {
     "ParameterKey": "SecretKeyBase",
     "ParameterValue": ""
   },

--- a/templates/fcrepo.json
+++ b/templates/fcrepo.json
@@ -67,6 +67,22 @@
     "RDSPort": {
       "Type": "String",
       "Description": "Database Port"
+    },
+    "HomePath": {
+      "Type": "String",
+      "Description": "Fedora home directory"
+    },
+    "BinaryStoreS3AccessKey": {
+      "Type": "String",
+      "Description": "Access Key Id providing access to binary store S3 bucket"
+    },
+    "BinaryStoreS3SecretKey": {
+      "Type": "String",
+      "Description": "Secret Access Key providing access to binary store S3 bucket"
+    },
+    "BinaryStoreS3Bucket": {
+      "Type": "String",
+      "Description": "Binary store S3 bucket"
     }
   },
   "Resources" : {
@@ -188,12 +204,15 @@
             "Namespace": "aws:elasticbeanstalk:container:tomcat:jvmoptions",
             "OptionName": "JVM Options",
             "Value": { "Fn::Join": ["", [
-                "-Duser.dir=\"/var/lib/fcrepo\"",
+                "-Dfcrepo.home=\"", { "Ref" : "HomePath" }, "\"",
                 " -Dfcrepo.postgresql.host=\"", { "Ref" : "RDSHostname" }, "\"",
                 " -Dfcrepo.postgresql.port=\"", { "Ref" : "RDSPort" }, "\"",
                 " -Dfcrepo.postgresql.username=\"", { "Ref" : "RDSUsername" }, "\"",
                 " -Dfcrepo.postgresql.password=\"", { "Ref" : "RDSPassword" }, "\"",
-                " -Dfcrepo.modeshape.configuration=\"classpath:/config/jdbc-postgresql/repository.json\""
+                " -Daws.accessKeyId=\"", { "Ref" : "BinaryStoreS3AccessKey" }, "\"",
+                " -Daws.secretKey=\"", { "Ref" : "BinaryStoreS3SecretKey" }, "\"",
+                " -Daws.bucket=\"", { "Ref" : "BinaryStoreS3Bucket" }, "\"",
+                " -Dfcrepo.modeshape.configuration=\"classpath:/config/jdbc-postgresql-s3/repository.json\""
               ]]}
           },
           {

--- a/templates/fcrepo.json
+++ b/templates/fcrepo.json
@@ -70,7 +70,7 @@
     },
     "HomePath": {
       "Type": "String",
-      "Description": "Fedora home directory"
+      "Description": "Fedora home directory path"
     },
     "BinaryStoreS3AccessKey": {
       "Type": "String",
@@ -212,6 +212,7 @@
                 " -Daws.accessKeyId=\"", { "Ref" : "BinaryStoreS3AccessKey" }, "\"",
                 " -Daws.secretKey=\"", { "Ref" : "BinaryStoreS3SecretKey" }, "\"",
                 " -Daws.bucket=\"", { "Ref" : "BinaryStoreS3Bucket" }, "\"",
+                " -Dfcrepo.streaming.parallel=true",
                 " -Dfcrepo.modeshape.configuration=\"classpath:/config/jdbc-postgresql-s3/repository.json\""
               ]]}
           },

--- a/templates/fcrepo.json
+++ b/templates/fcrepo.json
@@ -78,7 +78,8 @@
     },
     "BinaryStoreS3SecretKey": {
       "Type": "String",
-      "Description": "Secret Access Key providing access to binary store S3 bucket"
+      "Description": "Secret Access Key providing access to binary store S3 bucket",
+      "NoEcho": "true"
     },
     "BinaryStoreS3Bucket": {
       "Type": "String",

--- a/templates/stack.json
+++ b/templates/stack.json
@@ -69,6 +69,22 @@
       "Type" : "String",
       "Description" : "Launch the database in multiple availability zones"
     },
+    "FcrepoHomePath" : {
+      "Type" : "String",
+      "Description" : "Fcrepo home directory path"
+    },
+    "FcrepoS3AccessKey" : {
+      "Type" : "String",
+      "Description" : "Access Key Id for IAM user with access to Fcrepo bucket"
+    },
+    "FcrepoS3SecretKey" : {
+      "Type" : "String",
+      "Description" : "Secret Access Key for IAM user with access to Fcrepo bucket"
+    },
+    "FcrepoS3BucketName" : {
+      "Type" : "String",
+      "Description" : "Name of S3 bucket for Fedora binary content"
+    },
     "SecretKeyBase" : {
       "Type" : "String",
       "Description" : "Secret key for Rails",
@@ -227,7 +243,7 @@
         },
         {
           "Label" : { "default" : "Fedora Repository Configuration" },
-          "Parameters" : [ "FcrepoDatabaseUsername", "FcrepoDatabasePassword" ]
+          "Parameters" : [ "FcrepoDatabaseUsername", "FcrepoDatabasePassword", "FcrepoHomePath", "FcrepoS3AccessKey", "FcrepoS3SecretKey", "FcrepoS3BucketName" ]
         },
         {
           "Label" : { "default" : "Application Configuration" },
@@ -295,7 +311,11 @@
           "RDSHostname" : { "Fn::GetAtt" : ["fcrepodb", "Outputs.EndpointAddress"] },
           "RDSPort" : { "Fn::GetAtt" : ["fcrepodb", "Outputs.EndpointPort"] },
           "RDSUsername" : { "Ref" : "FcrepoDatabaseUsername" },
-          "RDSPassword" : { "Ref" : "FcrepoDatabasePassword" }
+          "RDSPassword" : { "Ref" : "FcrepoDatabasePassword" },
+          "HomePath" : { "Ref" : "FcrepoHomePath" },
+          "BinaryStoreS3AccessKey" : { "Ref" : "FcrepoS3AccessKey" },
+          "BinaryStoreS3SecretKey" : { "Ref" : "FcrepoS3SecretKey" },
+          "BinaryStoreS3Bucket" : { "Ref" : "FcrepoS3BucketName" }
         },
         "TemplateURL" : { "Fn::Join" : ["", ["https://s3.amazonaws.com/", { "Ref" : "S3Bucket" }, "/cloudformation/", { "Ref" : "S3KeyPrefix"}, "/templates/fcrepo.json"]] }
       }


### PR DESCRIPTION
Updates the Fedora configuration to write binary content to an S3 bucket. Resolves https://github.com/hybox/aws/issues/121 and https://github.com/hybox/aws/issues/143.

To avoid the need for retrieving credentials frequently and updating Fedora on the fly, the bucket and associated IAM user needed to access that bucket are expected to be created prior to creating the cloudformation stack. Updates to the README describe the required actions.